### PR TITLE
[WIP] Updated the visualizer to load dataloader from data module script instead of loading from visualiser json

### DIFF
--- a/examples/E2EBert/news_classifier.py
+++ b/examples/E2EBert/news_classifier.py
@@ -476,8 +476,6 @@ if __name__ == "__main__":
     #########################################################################
     import cloudpickle
     import json
-    test_loader = dm.test_dataloader()
-    loader_pickle = cloudpickle.dumps(test_loader)
     feature_type = "TextFeature"
     baseline = cloudpickle.dumps(baseline_func)
     transform_pickle = cloudpickle.dumps(transform)
@@ -486,7 +484,6 @@ if __name__ == "__main__":
     json_content = {}
     json_content["model"] = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                              'models/state_dict.pth')
-    json_content["loader"] = loader_pickle.decode('ISO-8859-1')
     json_content["feature_type"] = feature_type
     json_content["baseline"] = baseline.decode('ISO-8859-1')
     json_content["transform"] = transform_pickle.decode('ISO-8859-1')

--- a/examples/E2EBert/news_data_module.py
+++ b/examples/E2EBert/news_data_module.py
@@ -1,0 +1,227 @@
+import os
+import pandas as pd
+import pytorch_lightning as pl
+import requests
+import torch
+from pytorch_lightning import seed_everything
+from sklearn.model_selection import train_test_split
+from torch.utils.data import Dataset, DataLoader
+import torchtext.datasets as td
+from transformers import BertTokenizer
+from argparse import ArgumentParser
+
+
+class AGNewsDataset(Dataset):
+    def __init__(self, reviews, targets, tokenizer, max_length):
+        """
+        Performs initialization of tokenizer
+
+        :param reviews: AG news text
+        :param targets: labels
+        :param tokenizer: bert tokenizer
+        :param max_length: maximum length of the news text
+
+        """
+        self.reviews = reviews
+        self.targets = targets
+        self.tokenizer = tokenizer
+        self.max_length = max_length
+
+    def __len__(self):
+        """
+        :return: returns the number of datapoints in the dataframe
+
+        """
+        return len(self.reviews)
+
+    def __getitem__(self, item):
+        """
+        Returns the review text and the targets of the specified item
+
+        :param item: Index of sample review
+
+        :return: Returns the dictionary of review text, input ids, attention mask, targets
+        """
+        review = str(self.reviews[item])
+        target = self.targets[item]
+        encoded = self.tokenizer.encode_plus(
+            review,
+            add_special_tokens=True,
+            max_length=self.max_length,
+            return_token_type_ids=False,
+            padding="max_length",
+            return_attention_mask=True,
+            return_tensors="pt",
+            truncation=True,
+        )
+
+        return {
+            "review_text": review,
+            "input_ids": encoded["input_ids"].flatten(),
+            "attention_mask": encoded["attention_mask"].flatten(),
+            "targets": torch.tensor(target, dtype=torch.long),
+        }
+
+
+class BertDataModule(pl.LightningDataModule):
+    def __init__(self, **kwargs):
+        """
+        Initialization of inherited lightning data module
+        """
+        super(BertDataModule, self).__init__()
+        self.PRE_TRAINED_MODEL_NAME = "bert-base-uncased"
+        self.df_train = None
+        self.df_val = None
+        self.df_test = None
+        self.train_data_loader = None
+        self.val_data_loader = None
+        self.test_data_loader = None
+        self.input_embedding = None
+        self.MAX_LEN = 100
+        self.tokenizer = None
+        self.args = kwargs
+        self.NUM_SAMPLES_COUNT = 150
+        self.VOCAB_FILE_URL = "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt"
+        self.VOCAB_FILE = "bert_base_uncased_vocab.txt"
+
+    @staticmethod
+    def process_label(rating):
+        rating = int(rating)
+        return rating - 1
+
+    def prepare_data(self):
+        """
+        Implementation of abstract class
+        """
+
+    def setup(self, stage=None):
+        """
+        Downloads the data, parse it and split the data into train, test, validation data
+
+        :param stage: Stage - training or testing
+        """
+        # reading  the input
+        td.AG_NEWS(root="data", split=("train", "test"))
+        extracted_files = os.listdir("data")
+
+        train_csv_path = None
+        for fname in extracted_files:
+            if fname.endswith("train.csv"):
+                train_csv_path = os.path.join(os.getcwd(), "data", fname)
+
+        df = pd.read_csv(train_csv_path)
+
+        df.columns = ["label", "title", "description"]
+        df.sample(frac=1)
+        df = df.iloc[: self.NUM_SAMPLES_COUNT]
+
+        df["label"] = df.label.apply(self.process_label)
+
+        if not os.path.isfile(self.VOCAB_FILE):
+            filePointer = requests.get(self.VOCAB_FILE_URL, allow_redirects=True)
+            if filePointer.ok:
+                with open(self.VOCAB_FILE, "wb") as f:
+                    f.write(filePointer.content)
+            else:
+                raise RuntimeError("Error in fetching the vocab file")
+
+        self.tokenizer = BertTokenizer(self.VOCAB_FILE)
+
+        RANDOM_SEED = 42
+        seed_everything(RANDOM_SEED)
+
+        df_train, df_test = train_test_split(
+            df, test_size=0.2, random_state=RANDOM_SEED, stratify=df["label"]
+        )
+        df_train, df_val = train_test_split(
+            df_train, test_size=0.25, random_state=RANDOM_SEED, stratify=df_train["label"]
+        )
+
+        self.df_train = df_train
+        self.df_test = df_test
+        self.df_val = df_val
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        """
+        Returns the review text and the targets of the specified item
+
+        :param parent_parser: Application specific parser
+
+        :return: Returns the augmented arugument parser
+        """
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=16,
+            metavar="N",
+            help="input batch size for training (default: 16)",
+        )
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=3,
+            metavar="N",
+            help="number of workers (default: 0)",
+        )
+        return parser
+
+    def create_data_loader(self, df, tokenizer, max_len, batch_size):
+        """
+        Generic data loader function
+
+        :param df: Input dataframe
+        :param tokenizer: bert tokenizer
+        :param max_len: Max length of the news datapoint
+        :param batch_size: Batch size for training
+
+        :return: Returns the constructed dataloader
+        """
+        ds = AGNewsDataset(
+            reviews=df.description.to_numpy(),
+            targets=df.label.to_numpy(),
+            tokenizer=tokenizer,
+            max_length=max_len,
+        )
+
+        return DataLoader(
+            ds, batch_size=batch_size, num_workers=3
+        )
+
+    def train_dataloader(self):
+        """
+        :return: output - Train data loader for the given input
+        """
+        self.train_data_loader = self.create_data_loader(
+            self.df_train, self.tokenizer, self.MAX_LEN, 16
+        )
+        return self.train_data_loader
+
+    def val_dataloader(self):
+        """
+        :return: output - Validation data loader for the given input
+        """
+        self.val_data_loader = self.create_data_loader(
+            self.df_val, self.tokenizer, self.MAX_LEN, 16
+        )
+        return self.val_data_loader
+
+    def test_dataloader(self):
+        """
+        :return: output - Test data loader for the given input
+        """
+        self.test_data_loader = self.create_data_loader(
+            self.df_test, self.tokenizer, self.MAX_LEN, 16
+        )
+        return self.test_data_loader
+
+    def get_batch_data(self):
+        from captum.insights import Batch
+        self.setup()
+        dataloader = iter(self.test_dataloader())
+        while True:
+            inp_data = next(dataloader)
+            yield Batch(inputs=inp_data['input_ids'],
+                        labels=inp_data['targets']
+                        )

--- a/examples/cifar10/cifar10_data_module.py
+++ b/examples/cifar10/cifar10_data_module.py
@@ -3,21 +3,33 @@ import torchvision
 import torchvision.transforms as transforms
 
 
-def transform():
-    transforms.Compose(
-        [transforms.ToTensor(),
-         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+class Cifar10DataModule:
 
+    feature_type = "ImageFeature"
+    classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+    transform = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
 
-def setup():
-    trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
-                                            download=True, transform=transform)
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
-                                              shuffle=True, num_workers=2)
+    @staticmethod
+    def setup():
+        transformer = transforms.Compose(
+            [transforms.ToTensor(),
+             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+        trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                                                download=True, transform=transformer)
+        trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                                  shuffle=True, num_workers=2)
 
-    testset = torchvision.datasets.CIFAR10(root='./data', train=False,
-                                           download=False, transform=transform)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=4,
-                                             shuffle=False, num_workers=2)
-    return trainloader, testloader
+        testset = torchvision.datasets.CIFAR10(root='./data', train=False,
+                                               download=False, transform=transformer)
+        testloader = torch.utils.data.DataLoader(testset, batch_size=4,
+                                                 shuffle=False, num_workers=2)
+        return trainloader, testloader
 
+    @staticmethod
+    def get_batch_data():
+        from captum.insights import Batch
+        trainloader, testloader = Cifar10DataModule.setup()
+        loader = iter(testloader)
+        while True:
+            inp_data = next(loader)
+            yield Batch(inputs=inp_data[0], labels=inp_data[1])


### PR DESCRIPTION

Signed-off-by: Kasirajan Alayappan <kasirajan.alayappan@ideas2it.com>

## What changes are proposed in this pull request?

Currently, dataloader is pickled and stored as part of visualizer json after training is completed which increases the visualizer json file size. For example, bert model's visualizer json file is around 1.9GB with the dataloader. Hence, updated the visualizer script to load the dataloader from data module python script instead of visualizer json.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow TorchServe Deployment Plugin users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?
Components
- [ ] `area/deploy`: Main deployment plugin logic
- [ ] `area/build`: Build and test infrastructure for MLflow TorchServe Deployment Plugin
- [ ] `area/docs`: MLflow TorchServe Deployment Plugin documentation pages
- [x] `area/examples`: Example code


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
